### PR TITLE
Fix for entity-collision crash

### DIFF
--- a/src/main/java/org/dave/cm2/miniaturization/MultiblockRecipes.java
+++ b/src/main/java/org/dave/cm2/miniaturization/MultiblockRecipes.java
@@ -56,7 +56,7 @@ public class MultiblockRecipes {
 
         // No source block with a not mini fluid block below found
         if(insidePos == null) {
-            return null;
+            return ItemStack.EMPTY;
         }
 
         // 3. Use the previously gathered information to search for all connected blocks on the inside of the fluid


### PR DESCRIPTION
Basically we just had this happen on our server:
https://paste.ee/p/wR04H

Your method isn't returning `ItemStack.EMPTY`, but instead returns `null`, thus causing L48 in `BlockMiniaturizationFluid` to crash because `recipe` is `null`. :)