### PR TITLE
Added Null Handler for OpenComputers Environments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ repositories {
         name = "refinedstorage"
         url = "https://dl.bintray.com/raoulvdberge/dev/"
     }
+
+    maven {
+        name = "opencomputers"
+        url = "http://maven.cil.li/"
+    }
 }
 
 dependencies {
@@ -92,6 +97,9 @@ dependencies {
 
     deobfCompile "refinedstorage:refinedstorage:${config.rs.version}:api"
     //runtime "refinedstorage:refinedstorage:${config.rs.version}"
+
+    deobfCompile "li.cil.oc:OpenComputers:${config.oc.version}:api"
+    //runtime "li.cil.oc:OpenComputers:${config.oc.version}"
 }
 
 allprojects {

--- a/build.properties
+++ b/build.properties
@@ -4,3 +4,4 @@ mod.version=3.0.3
 jei.version=4.8.5.136
 waila.version=1.8.20-B35_1.12
 rs.version=1.5.23-1419
+oc.version=MC1.12.1-1.7.1.43

--- a/src/main/java/org/dave/compactmachines3/CompactMachines3.java
+++ b/src/main/java/org/dave/compactmachines3/CompactMachines3.java
@@ -55,7 +55,7 @@ public class CompactMachines3
 
         GuiHandler.init();
 
-        CapabilityNullHandlerRegistry.registerNullHandlers(event.getAsmData());
+        CapabilityNullHandlerRegistry.setAsmData(event.getAsmData());
 
         proxy.preInit(event);
     }
@@ -72,6 +72,8 @@ public class CompactMachines3
     @EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         proxy.postInit(event);
+
+        CapabilityNullHandlerRegistry.registerNullHandlers();
 
         ForgeChunkManager.setForcedChunkLoadingCallback(instance, new ChunkLoadingMachines());
     }

--- a/src/main/java/org/dave/compactmachines3/integration/CapabilityNullHandlerRegistry.java
+++ b/src/main/java/org/dave/compactmachines3/integration/CapabilityNullHandlerRegistry.java
@@ -9,8 +9,9 @@ import java.util.HashMap;
 
 public class CapabilityNullHandlerRegistry {
     private static HashMap<Capability, AbstractNullHandler> nullHandlers = new HashMap<>();
+    private static ASMDataTable asmData;
 
-    public static void registerNullHandlers(ASMDataTable asmData) {
+    public static void registerNullHandlers() {
         for(AbstractNullHandler nh : AnnotatedInstanceUtil.getNullHandlers(asmData)) {
             if(nullHandlers.containsKey(nh.getCapability())) {
                 continue;
@@ -27,5 +28,9 @@ public class CapabilityNullHandlerRegistry {
 
     public static <T> T getNullHandler(Capability<T> capability) {
         return (T) nullHandlers.get(capability);
+    }
+
+    public static void setAsmData(ASMDataTable asmData) {
+        CapabilityNullHandlerRegistry.asmData = asmData;
     }
 }

--- a/src/main/java/org/dave/compactmachines3/integration/opencomputers/EnvironmentNullHandler.java
+++ b/src/main/java/org/dave/compactmachines3/integration/opencomputers/EnvironmentNullHandler.java
@@ -1,0 +1,42 @@
+package org.dave.compactmachines3.integration.opencomputers;
+
+import li.cil.oc.api.Network;
+import li.cil.oc.api.network.Environment;
+import li.cil.oc.api.network.Message;
+import li.cil.oc.api.network.Node;
+import li.cil.oc.api.network.Visibility;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import org.dave.compactmachines3.integration.AbstractNullHandler;
+import org.dave.compactmachines3.integration.CapabilityNullHandler;
+
+@CapabilityNullHandler(mod = "opencomputers")
+public class EnvironmentNullHandler extends AbstractNullHandler implements Environment {
+
+	@CapabilityInject(Environment.class)
+	public static Capability<Environment> ENVIRONMENT_CAPABILITY = null;
+
+	private Node node = null;
+
+	@Override
+	public Node node() {
+		return node != null ? node : (node = Network.newNode(this, Visibility.Network).create());
+	}
+
+	@Override
+	public void onConnect(Node node) {
+	}
+
+	@Override
+	public void onDisconnect(Node node) {
+	}
+
+	@Override
+	public void onMessage(Message message) {
+	}
+
+	@Override
+	public Capability getCapability() {
+		return ENVIRONMENT_CAPABILITY;
+	}
+}


### PR DESCRIPTION
OC registers its capabilities in init, so looking for null handlers in postInit sounds like a good idea.

I haven't extensively tested it, but cables do visually connect properly now.

![Screenshot](https://user-images.githubusercontent.com/4135064/34079577-94d6afd8-e330-11e7-8782-c5f5b72d7ef1.png)

Should close #279 and resolve MightyPirates/OpenComputers#2677.