### PR TITLE
Update EnumMachineSize.java

### DIFF
--- a/src/main/java/org/dave/compactmachines3/reference/EnumMachineSize.java
+++ b/src/main/java/org/dave/compactmachines3/reference/EnumMachineSize.java
@@ -8,7 +8,7 @@ public enum EnumMachineSize implements IStringSerializable {
     NORMAL  (2, "normal", 8),
     LARGE   (3, "large", 10),
     GIANT   (4, "giant", 12),
-    MAXIMUM (5, "maximum", 14);
+    MAXIMUM (5, "maximum", 20);
 
     private int meta;
     private String name;


### PR DESCRIPTION
I saw that the maximum machine can't store Tier 8 energy core of DE，so I changed the size of the machine，how do you think this？
hope your reply。