### PR TITLE
Right-click issues on machine walls

### DIFF
--- a/src/main/java/org/dave/compactmachines3/block/BlockWall.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockWall.java
@@ -66,7 +66,7 @@ public class BlockWall extends BlockProtected {
         ItemStack playerStack = player.getHeldItemMainhand();
 
         if(playerStack.isEmpty()) {
-            return true;
+            return false;
         }
 
         if(player.isSneaking()) {
@@ -78,7 +78,7 @@ public class BlockWall extends BlockProtected {
         }
 
         if(world.isRemote || !(player instanceof EntityPlayerMP)) {
-            return false;
+            return playerStack.getItem() instanceof ItemTunnelTool;
         }
 
         if(world.provider.getDimension() != ConfigurationHandler.Settings.dimensionId) {

--- a/src/main/java/org/dave/compactmachines3/item/ItemPersonalShrinkingDevice.java
+++ b/src/main/java/org/dave/compactmachines3/item/ItemPersonalShrinkingDevice.java
@@ -64,7 +64,7 @@ public class ItemPersonalShrinkingDevice extends ItemBase {
             return new ActionResult(EnumActionResult.SUCCESS, stack);
         }
 
-        if(!world.isRemote && world.provider.getDimension() == ConfigurationHandler.Settings.dimensionId && player instanceof EntityPlayerMP) {
+        if(!world.isRemote && player instanceof EntityPlayerMP) {
             EntityPlayerMP serverPlayer = (EntityPlayerMP)player;
 
             if(player.isSneaking()) {
@@ -75,15 +75,12 @@ public class ItemPersonalShrinkingDevice extends ItemBase {
                 TextComponentTranslation tc = new TextComponentTranslation("item.compactmachines3.psd.spawnpoint_set");
                 tc.getStyle().setColor(TextFormatting.GREEN);
                 player.sendStatusMessage(tc, false);
-
-                return new ActionResult(EnumActionResult.SUCCESS, stack);
+            } else {
+                TeleportationTools.teleportPlayerOutOfMachine(serverPlayer);
             }
-
-            TeleportationTools.teleportPlayerOutOfMachine(serverPlayer);
-            return new ActionResult(EnumActionResult.SUCCESS, stack);
         }
 
-        return new ActionResult(EnumActionResult.FAIL, stack);
+        return new ActionResult(EnumActionResult.SUCCESS, stack);
     }
 
 


### PR DESCRIPTION
I partially reverted 9696598 to fix the tunnel side issue #368.

My reasoning is the following: when the player main-hand is empty it should let minecraft check the off-hand (`return false`) and when the world is remote it should stop the propagation if the item in hand is a tunnel but not with other items to let minecraft trigger their right-click event (`return playerStack.getItem() instanceof ItemTunnelTool`).

The other commit fixes something weird I found while debugging the other issue, when I right-clicked with the PSD having torches in my off-hand, a torch was placed on the wall but it was only visible from client-side.