### PR TITLE
Added additional null-checks to avoid client-side NPE's

### DIFF
--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityRedstoneTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityRedstoneTunnel.java
@@ -17,12 +17,28 @@ public class TileEntityRedstoneTunnel extends BaseTileEntityTunnel {
 
     public int getRedstonePowerInput(EnumFacing facing) {
         int coords = StructureTools.getCoordsForPos(this.getPos());
-        DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(coords);
-        if(dimpos == null) {
+
+        WorldSavedDataMachines wsd = WorldSavedDataMachines.INSTANCE;
+        if (wsd == null) {
             return 0;
         }
 
-        HashMap<EnumFacing, RedstoneTunnelData> tunnelMapping = WorldSavedDataMachines.INSTANCE.redstoneTunnels.get(coords);
+        HashMap<Integer, DimensionBlockPos> machinePositions = wsd.machinePositions;
+        if (machinePositions == null) {
+            return 0;
+        }
+
+        DimensionBlockPos dimpos = machinePositions.get(coords);
+        if (dimpos == null) {
+            return 0;
+        }
+
+        HashMap<Integer, HashMap<EnumFacing, RedstoneTunnelData>> redstoneTunnels = wsd.redstoneTunnels;
+        if (redstoneTunnels == null) {
+            return 0;
+        }
+
+        HashMap<EnumFacing, RedstoneTunnelData> tunnelMapping = redstoneTunnels.get(coords);
         if(tunnelMapping == null) {
             return 0;
         }


### PR DESCRIPTION
Added additional null-checks to avoid client-side NPE's in some edge cases involving (at least) Cyclic machines/blocks being placed right next to a Redstone Tunnel.