### PR TITLE
Added additional null-checks to avoid client-side NPE's

### DIFF
--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
@@ -13,6 +13,8 @@ import org.dave.compactmachines3.world.WorldSavedDataMachines;
 import org.dave.compactmachines3.world.tools.DimensionTools;
 import org.dave.compactmachines3.world.tools.StructureTools;
 
+import java.util.HashMap;
+
 public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilityProvider, IRemoteBlockProvider {
 
     @Override
@@ -50,8 +52,18 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
 
             return super.hasCapability(capability, facing);
         }
+        
+        WorldSavedDataMachines wsd = WorldSavedDataMachines.INSTANCE;
+        if (wsd == null) {
+        	return false;
+        }
+        
+        HashMap<Integer, DimensionBlockPos> machinePositions = wsd.machinePositions;
+        if (machinePositions == null) {
+        	return false;
+        }
 
-        DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
+        DimensionBlockPos dimpos = machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return false;
         }


### PR DESCRIPTION
Added additional null-checks to avoid client-side NPE's in some edge cases involving (at least) Mekanism machines/blocks being placed right next to a TileEntity Tunnel.

Fixes [#402](https://github.com/thraaawn/CompactMachines/issues/402)

Took the exact same approach as [#391](https://github.com/thraaawn/CompactMachines/pull/391)