### PR TITLE
fixed server crash on startup

### DIFF
--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
@@ -98,7 +98,17 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
             return super.getCapability(capability, facing);
         }
 
-        DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
+        WorldSavedDataMachines wsd = WorldSavedDataMachines.INSTANCE;
+        if (wsd == null) {
+            return null;
+        }
+
+        HashMap<Integer, DimensionBlockPos> machinePositions = wsd.machinePositions;
+        if (machinePositions == null) {
+            return null;
+        }
+
+        DimensionBlockPos dimpos = machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return null;
         }


### PR DESCRIPTION
Fixed crash when WorldSavedDataMachines.INSTANCE is null in "getCapability".

This fixed a NullPointerException on server startup when using Mekanism cables with compact machines tunnels.
I noticed there are 2 methods: `hasCapability` and `getCapability`.
Both methods do pretty much the same except one returns an object and the other returns a bool.
Also getCapability is missing some null checks that hasCapability has.
I added those null checks and now it doesnt crash anymore but the proper solution is to make getCapability 100% safe and then just do
> getCapability(x, y) != null

in hasCapability.
I didnt do that because im too scared of breaking stuff since i have no idea about the codebase.

This might fix #381

heres part of the stack trace from the crash report if thats relevant.
```Description: Exception in server tick loop

java.lang.NullPointerException
    at org.dave.compactmachines3.tile.TileEntityTunnel.hasCapability(TileEntityTunnel.java:54)
    at mekanism.common.util.CapabilityUtils.hasCapability(CapabilityUtils.java:16)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.canConnectMutual(TileEntitySidedPipe.java:262)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.getPossibleTransmitterConnections(TileEntitySidedPipe.java:132)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.refreshConnections(TileEntitySidedPipe.java:368)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.recheckConnections(TileEntitySidedPipe.java:428)
    at mekanism.common.tile.transmitter.TileEntityTransmitter.recheckConnections(TileEntityTransmitter.java:133)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.refreshConnections(TileEntitySidedPipe.java:388)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.recheckConnections(TileEntitySidedPipe.java:428)
    at mekanism.common.tile.transmitter.TileEntityTransmitter.recheckConnections(TileEntityTransmitter.java:133)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.refreshConnections(TileEntitySidedPipe.java:388)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.recheckConnections(TileEntitySidedPipe.java:428)
    at mekanism.common.tile.transmitter.TileEntityTransmitter.recheckConnections(TileEntityTransmitter.java:133)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.refreshConnections(TileEntitySidedPipe.java:388)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.recheckConnections(TileEntitySidedPipe.java:428)
    at mekanism.common.tile.transmitter.TileEntityTransmitter.recheckConnections(TileEntityTransmitter.java:133)
    at mekanism.common.tile.transmitter.TileEntitySidedPipe.refreshConnections(TileEntitySidedPipe.java:388)```