### PR TITLE
Fix dead link to refinedstorage & Add null checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ repositories {
 
     maven {
         name = "refinedstorage"
-        url = "https://repo.raoulvdberge.com/"
+        url = "https://repo.refinedmods.com/"
     }
 
     maven {

--- a/src/main/java/org/dave/compactmachines3/block/BlockBaseTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockBaseTunnel.java
@@ -84,6 +84,9 @@ public abstract class BlockBaseTunnel extends BlockProtected implements ITileEnt
     }
 
     public void notifyOverworldNeighbor(BlockPos pos) {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(pos));
         if(dimpos == null) {
             return;

--- a/src/main/java/org/dave/compactmachines3/block/BlockMachine.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockMachine.java
@@ -210,6 +210,10 @@ public class BlockMachine extends BlockBase implements IMetaBlockName, ITileEnti
             return;
         }
 
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
+
         TileEntityMachine te = (TileEntityMachine) world.getTileEntity(pos);
         WorldSavedDataMachines.INSTANCE.removeMachinePosition(te.coords);
 
@@ -277,6 +281,9 @@ public class BlockMachine extends BlockBase implements IMetaBlockName, ITileEnti
                 if (coords != -1) {
                     tileEntityMachine.coords = coords;
                     if(!world.isRemote) {
+                        if (WorldSavedDataMachines.INSTANCE == null) {
+                            return;
+                        }
                         WorldSavedDataMachines.INSTANCE.addMachinePosition(tileEntityMachine.coords, pos, world.provider.getDimension(), tileEntityMachine.getSize());
                         StructureTools.setBiomeForCoords(coords, world.getBiome(pos));
                     }

--- a/src/main/java/org/dave/compactmachines3/block/BlockRedstoneTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockRedstoneTunnel.java
@@ -78,7 +78,9 @@ public class BlockRedstoneTunnel extends BlockBaseTunnel {
                 faceX = hitX;
             }
         }
-
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return false;
+        }
         if(faceX >= 0.69d && faceX <= 0.94d && faceY >= 0.69d && faceY <= 0.94d) {
             world.setBlockState(pos, state.withProperty(IS_OUTPUT, !state.getValue(IS_OUTPUT)));
             WorldSavedDataMachines.INSTANCE.toggleRedstoneTunnelOutput(pos);

--- a/src/main/java/org/dave/compactmachines3/block/BlockTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockTunnel.java
@@ -46,6 +46,9 @@ public class BlockTunnel extends BlockBaseTunnel {
         EnumFacing connectedSide = state.getValue(MACHINE_SIDE);
         EnumFacing nextDirection = StructureTools.getNextDirection(connectedSide);
 
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return false;
+        }
         int coords = StructureTools.getCoordsForPos(pos);
         HashMap sideMapping = WorldSavedDataMachines.INSTANCE.tunnels.get(coords);
         while(sideMapping != null) {

--- a/src/main/java/org/dave/compactmachines3/block/BlockWall.java
+++ b/src/main/java/org/dave/compactmachines3/block/BlockWall.java
@@ -86,6 +86,9 @@ public class BlockWall extends BlockProtected {
         }
 
         if(playerStack.getItem() instanceof ItemTunnelTool) {
+            if (WorldSavedDataMachines.INSTANCE == null) {
+                return false;
+            }
             EnumFacing tunnelSide = EnumFacing.DOWN;
             int coords = StructureTools.getCoordsForPos(pos);
             HashMap sideMapping = WorldSavedDataMachines.INSTANCE.tunnels.get(coords);
@@ -114,6 +117,9 @@ public class BlockWall extends BlockProtected {
         if(playerStack.getItem() instanceof ItemRedstoneTunnelTool) {
             EnumFacing tunnelSide = EnumFacing.DOWN;
             int coords = StructureTools.getCoordsForPos(pos);
+            if (WorldSavedDataMachines.INSTANCE == null) {
+                return false;
+            }
             HashMap<EnumFacing, RedstoneTunnelData> sideMapping = WorldSavedDataMachines.INSTANCE.redstoneTunnels.get(coords);
             while(sideMapping != null && tunnelSide != null) {
                 if(sideMapping.get(tunnelSide) == null) {

--- a/src/main/java/org/dave/compactmachines3/command/CommandMachinesGive.java
+++ b/src/main/java/org/dave/compactmachines3/command/CommandMachinesGive.java
@@ -35,7 +35,7 @@ public class CommandMachinesGive extends CommandBaseExt {
 
         EntityPlayerMP player = (EntityPlayerMP) sender.getCommandSenderEntity();
         int coords = Integer.parseInt(args[0]);
-        if(coords < 0 || coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
+        if( coords < 0 || WorldSavedDataMachines.INSTANCE == null || coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
             return;
         }
 

--- a/src/main/java/org/dave/compactmachines3/command/CommandMachinesView.java
+++ b/src/main/java/org/dave/compactmachines3/command/CommandMachinesView.java
@@ -28,7 +28,9 @@ public class CommandMachinesView extends CommandBaseExt {
         if(!(sender.getCommandSenderEntity() instanceof EntityPlayerMP)) {
             return;
         }
-
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         int coords = WorldSavedDataMachines.INSTANCE.nextCoord-1;
         if(args.length == 1) {
             coords = Integer.parseInt(args[0]);

--- a/src/main/java/org/dave/compactmachines3/command/CommandSchemaSave.java
+++ b/src/main/java/org/dave/compactmachines3/command/CommandSchemaSave.java
@@ -49,7 +49,7 @@ public class CommandSchemaSave extends CommandBaseExt {
 
             List<BlockInformation> blockList = StructureTools.createNewSchema(coords);
 
-            if(blockList != null) {
+            if(blockList != null && WorldSavedDataMachines.INSTANCE != null) {
                 Schema schema = new Schema(args[0]);
                 schema.setBlocks(blockList);
                 schema.setSize(WorldSavedDataMachines.INSTANCE.machineSizes.get(coords));

--- a/src/main/java/org/dave/compactmachines3/misc/PlayerEventHandler.java
+++ b/src/main/java/org/dave/compactmachines3/misc/PlayerEventHandler.java
@@ -48,7 +48,9 @@ public class PlayerEventHandler {
         if(event.player.getEntityWorld().provider.getDimension() != ConfigurationHandler.Settings.dimensionId) {
             return;
         }
-
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         int bedCoords = WorldSavedDataMachines.INSTANCE.getBedCoords(event.player);
         boolean bedInCM = bedCoords != -1;
 
@@ -171,6 +173,9 @@ public class PlayerEventHandler {
         }
 
         int actualCoords = StructureTools.getCoordsForPos(new BlockPos(event.player.posX, event.player.posY, event.player.posZ));
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         EnumMachineSize enumSize = WorldSavedDataMachines.INSTANCE.machineSizes.getOrDefault(lastCoords, null);
         if(enumSize == null) {
             // This should only happen after someone updated before this feature was implemented:

--- a/src/main/java/org/dave/compactmachines3/network/MessageMachineContent.java
+++ b/src/main/java/org/dave/compactmachines3/network/MessageMachineContent.java
@@ -26,7 +26,9 @@ public class MessageMachineContent implements IMessage {
     public MessageMachineContent(int coords) {
         this.coords = coords;
         WorldSavedDataMachines data = WorldSavedDataMachines.INSTANCE;
-
+        if (data == null) {
+            return;
+        }
         machinePos = data.getMachinePosition(coords);
         machineSize = data.machineSizes.getOrDefault(coords, EnumMachineSize.MAXIMUM).getDimension();
 

--- a/src/main/java/org/dave/compactmachines3/network/MessagePlayerWhiteListToggleHandler.java
+++ b/src/main/java/org/dave/compactmachines3/network/MessagePlayerWhiteListToggleHandler.java
@@ -14,7 +14,7 @@ public class MessagePlayerWhiteListToggleHandler implements IMessageHandler<Mess
     @Override
     public MessagePlayerWhiteListToggle onMessage(MessagePlayerWhiteListToggle message, MessageContext ctx) {
         int coords = message.coords;
-        if(message.coords < 0 || message.coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
+        if(message.coords < 0 || WorldSavedDataMachines.INSTANCE == null || message.coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
             return null;
         }
 

--- a/src/main/java/org/dave/compactmachines3/network/MessageRequestMachineActionHandler.java
+++ b/src/main/java/org/dave/compactmachines3/network/MessageRequestMachineActionHandler.java
@@ -24,6 +24,9 @@ public class MessageRequestMachineActionHandler implements IMessageHandler<Messa
     @Override
     public MessageMachineContent onMessage(MessageRequestMachineAction message, MessageContext ctx) {
         int coords = message.coords;
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return null;
+        }
         if(message.action == MessageRequestMachineAction.Action.REFRESH) {
             if(message.coords < 0) {
                 coords = WorldSavedDataMachines.INSTANCE.nextCoord-1;

--- a/src/main/java/org/dave/compactmachines3/network/MessageSetMachineNameHandler.java
+++ b/src/main/java/org/dave/compactmachines3/network/MessageSetMachineNameHandler.java
@@ -14,7 +14,7 @@ public class MessageSetMachineNameHandler implements IMessageHandler<MessageSetM
     @Override
     public MessageSetMachineName onMessage(MessageSetMachineName message, MessageContext ctx) {
         int coords = message.coords;
-        if(message.coords < 0 || message.coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
+        if(message.coords < 0 || WorldSavedDataMachines.INSTANCE == null || message.coords >= WorldSavedDataMachines.INSTANCE.nextCoord) {
             return null;
         }
 

--- a/src/main/java/org/dave/compactmachines3/tile/BaseTileEntityTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/BaseTileEntityTunnel.java
@@ -21,6 +21,9 @@ public class BaseTileEntityTunnel extends TileEntity implements ITickable {
     }
 
     public ItemStack getConnectedPickBlock() {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return ItemStack.EMPTY;
+        }
         DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return ItemStack.EMPTY;

--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityMachine.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityMachine.java
@@ -352,7 +352,7 @@ public class TileEntityMachine extends TileEntity implements ICapabilityProvider
      * Capabilities
      */
     public RedstoneTunnelData getRedstoneTunnelForSide(EnumFacing side) {
-        if(!WorldSavedDataMachines.INSTANCE.redstoneTunnels.containsKey(this.coords)) {
+        if(WorldSavedDataMachines.INSTANCE == null || !WorldSavedDataMachines.INSTANCE.redstoneTunnels.containsKey(this.coords)) {
             return null;
         }
 

--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
@@ -19,6 +19,9 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
 
     @Override
     public BlockPos getConnectedBlockPosition(EnumFacing side) {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return null;
+        }
         DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return null;
@@ -35,6 +38,9 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
 
     @Override
     public int getConnectedDimensionId(EnumFacing side) {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return 0;
+        }
         DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return 0;
@@ -97,7 +103,9 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
 
             return super.getCapability(capability, facing);
         }
-
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return null;
+        }
         DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return null;

--- a/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
+++ b/src/main/java/org/dave/compactmachines3/tile/TileEntityTunnel.java
@@ -103,10 +103,18 @@ public class TileEntityTunnel extends BaseTileEntityTunnel implements ICapabilit
 
             return super.getCapability(capability, facing);
         }
-        if (WorldSavedDataMachines.INSTANCE == null) {
+        
+        WorldSavedDataMachines wsd = WorldSavedDataMachines.INSTANCE;
+        if (wsd == null) {
             return null;
         }
-        DimensionBlockPos dimpos = WorldSavedDataMachines.INSTANCE.machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
+
+        HashMap<Integer, DimensionBlockPos> machinePositions = wsd.machinePositions;
+        if (machinePositions == null) {
+            return null;
+        }
+
+        DimensionBlockPos dimpos = machinePositions.get(StructureTools.getCoordsForPos(this.getPos()));
         if(dimpos == null) {
             return null;
         }

--- a/src/main/java/org/dave/compactmachines3/world/tools/SpawnTools.java
+++ b/src/main/java/org/dave/compactmachines3/world/tools/SpawnTools.java
@@ -21,6 +21,9 @@ public class SpawnTools {
         int count = 0;
 
         WorldServer machineWorld = DimensionTools.getServerMachineWorld();
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return 0;
+        }
 
         EnumMachineSize size = WorldSavedDataMachines.INSTANCE.machineSizes.get(coords);
         if(size == null) {

--- a/src/main/java/org/dave/compactmachines3/world/tools/StructureTools.java
+++ b/src/main/java/org/dave/compactmachines3/world/tools/StructureTools.java
@@ -135,6 +135,9 @@ public class StructureTools {
     }
 
     public static List<BlockInformation> createNewSchema(int coords) {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return null;
+        }
         TileEntity machine = WorldSavedDataMachines.INSTANCE.getMachinePosition(coords).getTileEntity();
         if(machine != null && machine instanceof TileEntityMachine) {
             return createNewSchema((TileEntityMachine) machine);
@@ -187,6 +190,9 @@ public class StructureTools {
     }
 
     public static void restoreSchema(Schema schema, int coords) {
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         List<BlockInformation> blockList = schema.getBlocks();
 
         TileEntity te = WorldSavedDataMachines.INSTANCE.getMachinePosition(coords).getTileEntity();

--- a/src/main/java/org/dave/compactmachines3/world/tools/TeleportationTools.java
+++ b/src/main/java/org/dave/compactmachines3/world/tools/TeleportationTools.java
@@ -47,6 +47,10 @@ public class TeleportationTools {
 
         machine.initStructure();
 
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return false;
+        }
+
         WorldSavedDataMachines.INSTANCE.addMachinePosition(machine.coords, pos, world.provider.getDimension(), machine.getSize());
 
         TeleportationTools.teleportPlayerToMachine((EntityPlayerMP) player, machine);
@@ -66,6 +70,9 @@ public class TeleportationTools {
 
     public static void teleportToSkyworldHome(EntityPlayer player) {
         if(!SkyWorldSavedData.instance.hasSkyworldHome(player)) {
+            return;
+        }
+        if (WorldSavedDataMachines.INSTANCE == null) {
             return;
         }
 
@@ -125,7 +132,9 @@ public class TeleportationTools {
             coordHistory.appendTag(toAppend);
             playerNBT.setTag("compactmachines3-coordHistory", coordHistory);
         }
-
+        if (WorldSavedDataMachines.INSTANCE == null) {
+            return;
+        }
         TileEntityMachine machine = WorldSavedDataMachines.INSTANCE.getMachine(coords);
         if(machine.hasNewSchema()) {
             Schema schema = SchemaRegistry.instance.getSchema(machine.getSchemaName());
@@ -166,7 +175,9 @@ public class TeleportationTools {
                 coords = getLastKnownCoords(player);
                 playerNBT.removeTag("compactmachines3-coordHistory");
             }
-
+            if (WorldSavedDataMachines.INSTANCE == null) {
+                return;
+            }
             DimensionBlockPos pos = WorldSavedDataMachines.INSTANCE.machinePositions.get(coords);
 
             BlockPos startPoint;


### PR DESCRIPTION
I patched a couple of things: 
- Fixed refined storage repository location to fix gradlew build 
- Applied sum-catnip's patch: https://github.com/thraaawn/CompactMachines/pull/422
- Added null checks for WorldSavedDataMachines.INSTANCE in most locations that I found it referenced. 

Latter is maybe checking it on things this can't happen, but since I had issues on my server on 2 different locations, I figured it's best to check all of them. 




