### PR TITLE
Fix "rename" and "enter machine" tooltips in machine preview GUI

### DIFF
--- a/src/main/java/org/dave/compactmachines3/gui/framework/GUI.java
+++ b/src/main/java/org/dave/compactmachines3/gui/framework/GUI.java
@@ -1,17 +1,15 @@
 package org.dave.compactmachines3.gui.framework;
 
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.client.config.GuiUtils;
 import org.dave.compactmachines3.CompactMachines3;
 import org.dave.compactmachines3.gui.framework.widgets.Widget;
 import org.dave.compactmachines3.gui.framework.widgets.WidgetPanel;
 
 
 public class GUI extends WidgetPanel {
-    private static ResourceLocation tabIcons;
+    private static final ResourceLocation tabIcons = new ResourceLocation(CompactMachines3.MODID, "textures/gui/tabicons.png");
 
     public boolean hasTabs = false;
 
@@ -20,13 +18,11 @@ public class GUI extends WidgetPanel {
         this.setY(y);
         this.setWidth(width);
         this.setHeight(height);
-
-        this.tabIcons = new ResourceLocation(CompactMachines3.MODID, "textures/gui/tabicons.png");
     }
 
     public void drawGUI(GuiScreen screen) {
-        this.setX((screen.width - this.width)/2);
-        this.setY((screen.height - this.height)/2);
+        this.setX((screen.width - this.width) / 2);
+        this.setY((screen.height - this.height) / 2);
 
         this.shiftAndDraw(screen);
     }
@@ -62,7 +58,7 @@ public class GUI extends WidgetPanel {
         int width = this.width;
         int xOffset = 0;
 
-        if(hasTabs) {
+        if (hasTabs) {
             width -= 32;
             xOffset += 32;
         }
@@ -71,44 +67,36 @@ public class GUI extends WidgetPanel {
         screen.drawTexturedModalRect(xOffset, 0, texOffsetX, texOffsetY, 4, 4);
 
         // Top right corner
-        screen.drawTexturedModalRect(xOffset+width - 4, 0, texOffsetX + 4 + 64, texOffsetY, 4, 4);
+        screen.drawTexturedModalRect(xOffset + width - 4, 0, texOffsetX + 4 + 64, texOffsetY, 4, 4);
 
         // Bottom Left corner
         screen.drawTexturedModalRect(xOffset, this.height - 4, texOffsetX, texOffsetY + 4 + 64, 4, 4);
 
         // Bottom Right corner
-        screen.drawTexturedModalRect(xOffset+width - 4, this.height - 4, texOffsetX + 4 + 64, texOffsetY + 4 + 64, 4, 4);
+        screen.drawTexturedModalRect(xOffset + width - 4, this.height - 4, texOffsetX + 4 + 64, texOffsetY + 4 + 64, 4, 4);
 
         // Top edge
-        GUIHelper.drawStretchedTexture(xOffset+4, 0, width - 8, 4, texOffsetX + 4, texOffsetY, 64, 4);
+        GUIHelper.drawStretchedTexture(xOffset + 4, 0, width - 8, 4, texOffsetX + 4, texOffsetY, 64, 4);
 
         // Bottom edge
-        GUIHelper.drawStretchedTexture(xOffset+4, this.height - 4, width - 8, 4, texOffsetX + 4, texOffsetY + 4 + 64, 64, 4);
+        GUIHelper.drawStretchedTexture(xOffset + 4, this.height - 4, width - 8, 4, texOffsetX + 4, texOffsetY + 4 + 64, 64, 4);
 
         // Left edge
-        GUIHelper.drawStretchedTexture(xOffset, 4, 4, this.height - 8, texOffsetX, texOffsetY+4, 4, 64);
+        GUIHelper.drawStretchedTexture(xOffset, 4, 4, this.height - 8, texOffsetX, texOffsetY + 4, 4, 64);
 
         // Right edge
-        GUIHelper.drawStretchedTexture(xOffset+width - 4, 4, 4, this.height - 8, texOffsetX + 64 + 4, texOffsetY + 3, 4, 64);
+        GUIHelper.drawStretchedTexture(xOffset + width - 4, 4, 4, this.height - 8, texOffsetX + 64 + 4, texOffsetY + 3, 4, 64);
 
-        GUIHelper.drawStretchedTexture(xOffset+4, 4, width - 8, this.height - 8, texOffsetX + 4, texOffsetY+4, 64, 64);
+        GUIHelper.drawStretchedTexture(xOffset + 4, 4, width - 8, this.height - 8, texOffsetX + 4, texOffsetY + 4, 64, 64);
 
         GlStateManager.popMatrix();
     }
 
     public void drawTooltips(GuiScreen screen, int mouseX, int mouseY) {
         Widget hoveredWidget = getHoveredWidget(mouseX, mouseY);
-        FontRenderer font = screen.mc.fontRenderer;
 
-        if(hoveredWidget != null && hoveredWidget.getTooltip() != null) {
-            if(hoveredWidget.getTooltip().size() > 0) {
-                GuiUtils.drawHoveringText(hoveredWidget.getTooltip(), mouseX, mouseY, width, height, 180, font);
-            }/* else {
-                List<String> tooltips = new ArrayList<>();
-                tooltips.add(hoveredWidget.toString());
-                GuiUtils.drawHoveringText(tooltips, mouseX, mouseY, width, height, 180, font);
-            }*/
+        if (hoveredWidget != null && hoveredWidget.hasTooltip()) {
+            screen.drawHoveringText(hoveredWidget.getTooltip(), mouseX, mouseY);
         }
     }
-
 }

--- a/src/main/java/org/dave/compactmachines3/gui/framework/widgets/Widget.java
+++ b/src/main/java/org/dave/compactmachines3/gui/framework/widgets/Widget.java
@@ -42,8 +42,8 @@ public class Widget {
         }));
     }
 
-    public boolean hasToolTip() {
-        return tooltipLines != null && tooltipLines.size() > 0;
+    public boolean hasTooltip() {
+        return tooltipLines != null && !tooltipLines.isEmpty();
     }
 
     public List<String> getTooltip() {
@@ -61,20 +61,16 @@ public class Widget {
 
     public Widget setTooltipLines(String ... tooltipLines) {
         this.tooltipLines = new ArrayList<>();
-        for(String line : tooltipLines) {
-            this.tooltipLines.add(line);
-        }
+        this.tooltipLines.addAll(Arrays.asList(tooltipLines));
         return this;
     }
 
-    public Widget addTooltipLine(String ... tooltipLines) {
-        for(String line : tooltipLines) {
-            this.tooltipLines.add(line);
-        }
+    public Widget addTooltipLines(String ... tooltipLines) {
+        this.tooltipLines.addAll(Arrays.asList(tooltipLines));
         return this;
     }
 
-    public Widget addTooltipLine(List<String> strings) {
+    public Widget addTooltipLines(List<String> strings) {
         this.tooltipLines.addAll(strings);
         return this;
     }

--- a/src/main/java/org/dave/compactmachines3/gui/framework/widgets/WidgetPanel.java
+++ b/src/main/java/org/dave/compactmachines3/gui/framework/widgets/WidgetPanel.java
@@ -2,7 +2,13 @@ package org.dave.compactmachines3.gui.framework.widgets;
 
 import com.google.common.collect.Sets;
 import net.minecraft.client.gui.GuiScreen;
-import org.dave.compactmachines3.gui.framework.event.*;
+import org.dave.compactmachines3.gui.framework.event.IEvent;
+import org.dave.compactmachines3.gui.framework.event.MouseClickEvent;
+import org.dave.compactmachines3.gui.framework.event.MouseEnterEvent;
+import org.dave.compactmachines3.gui.framework.event.MouseExitEvent;
+import org.dave.compactmachines3.gui.framework.event.MouseMoveEvent;
+import org.dave.compactmachines3.gui.framework.event.ValueChangedEvent;
+import org.dave.compactmachines3.gui.framework.event.WidgetEventResult;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -19,21 +25,21 @@ public class WidgetPanel extends Widget {
 
         // Pass mouse move events along to the children, shift positions accordingly
         // Also notify widgets when the mouse entered or exited their area
-        this.addListener(MouseMoveEvent.class, (event, widget)-> {
+        this.addListener(MouseMoveEvent.class, (event, widget) -> {
 
-            for(Widget child : children) {
+            for (Widget child : children) {
                 MouseMoveEvent shifted = new MouseMoveEvent(event.x, event.y);
                 child.fireEvent(shifted);
 
-                if(!child.isPosInside(event.x, event.y)) {
-                    if(previouslyHovered.contains(child)) {
+                if (!child.isPosInside(event.x, event.y)) {
+                    if (previouslyHovered.contains(child)) {
                         child.fireEvent(new MouseExitEvent());
                         previouslyHovered.remove(child);
                     }
                     continue;
                 }
 
-                if(!previouslyHovered.contains(child)) {
+                if (!previouslyHovered.contains(child)) {
                     child.fireEvent(new MouseEnterEvent());
                     previouslyHovered.add(child);
                 }
@@ -47,16 +53,16 @@ public class WidgetPanel extends Widget {
             int innerX = event.x - widget.getActualX();
             int innerY = event.y - widget.getActualY();
 
-            for(Widget child : children) {
-                if(!child.visible) {
+            for (Widget child : children) {
+                if (!child.visible) {
                     continue;
                 }
 
-                if(!child.isPosInside(event.x, event.y)) {
+                if (!child.isPosInside(event.x, event.y)) {
                     continue;
                 }
 
-                if(child.fireEvent(new MouseClickEvent(event.x, event.y, event.button)) == WidgetEventResult.HANDLED) {
+                if (child.fireEvent(new MouseClickEvent(event.x, event.y, event.button)) == WidgetEventResult.HANDLED) {
                     return WidgetEventResult.HANDLED;
                 }
             }
@@ -71,13 +77,13 @@ public class WidgetPanel extends Widget {
 
         // Forward all other events to all children directly
         this.addAnyListener(((event, widget) -> {
-            if(eventsToIgnore.contains(event.getClass())) {
+            if (eventsToIgnore.contains(event.getClass())) {
                 return WidgetEventResult.CONTINUE_PROCESSING;
             }
 
-            for(Widget child : children) {
+            for (Widget child : children) {
                 WidgetEventResult immediateResult = child.fireEvent(event);
-                if(immediateResult == WidgetEventResult.HANDLED) {
+                if (immediateResult == WidgetEventResult.HANDLED) {
                     return WidgetEventResult.HANDLED;
                 }
             }
@@ -112,8 +118,8 @@ public class WidgetPanel extends Widget {
     }
 
     private void getHoveredWidgets(List<Widget> result) {
-        for(Widget widget : previouslyHovered) {
-            if(widget instanceof WidgetPanel) {
+        for (Widget widget : previouslyHovered) {
+            if (widget instanceof WidgetPanel) {
                 ((WidgetPanel) widget).getHoveredWidgets(result);
             } else {
                 result.add(widget);
@@ -122,22 +128,20 @@ public class WidgetPanel extends Widget {
     }
 
     public Widget getHoveredWidget(int mouseX, int mouseY) {
-        for(Widget child : children) {
-            if(!child.visible) {
+        for (Widget child : this.children) {
+            if (!child.visible)
                 continue;
-            }
 
-            if(child.isPosInside(mouseX, mouseY)) {
-                Widget maybeResult = null;
-                if(child instanceof WidgetPanel) {
-                    maybeResult = ((WidgetPanel) child).getHoveredWidget(mouseX, mouseY);
+            if (child.isPosInside(mouseX, mouseY)) {
+                if (child instanceof WidgetPanel) {
+                    Widget possible = ((WidgetPanel) child).getHoveredWidget(mouseX, mouseY);
+
+                    if (possible != null && possible.hasTooltip()) {
+                        return possible;
+                    }
+                } else if (child.hasTooltip()) {
+                    return child;
                 }
-
-                if(maybeResult != null && maybeResult.hasToolTip()) {
-                    return maybeResult;
-                }
-
-                return child;
             }
         }
 
@@ -146,10 +150,9 @@ public class WidgetPanel extends Widget {
 
     @Override
     public void draw(GuiScreen screen) {
-        for(Widget child : children) {
-            if(!child.visible) {
+        for (Widget child : children) {
+            if (!child.visible)
                 continue;
-            }
 
             child.shiftAndDraw(screen);
         }

--- a/src/main/java/org/dave/compactmachines3/gui/framework/widgets/WidgetTabsPanel.java
+++ b/src/main/java/org/dave/compactmachines3/gui/framework/widgets/WidgetTabsPanel.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Map;
 
 public class WidgetTabsPanel extends WidgetPanel {
-    private List<WidgetPanel> pages = new ArrayList<>();
-    private Map<WidgetPanel, ItemStack> pageStacks = new HashMap<>();
-    private Map<WidgetPanel, List<String>> pageTooltips = new HashMap<>();
+    private final List<WidgetPanel> pages = new ArrayList<>();
+    private final Map<WidgetPanel, ItemStack> pageStacks = new HashMap<>();
+    private final Map<WidgetPanel, List<String>> pageTooltips = new HashMap<>();
 
     private WidgetPanel activePanel = null;
 
@@ -77,7 +77,7 @@ public class WidgetTabsPanel extends WidgetPanel {
             result.add(button);
 
             if(pageTooltips.containsKey(page)) {
-                button.addTooltipLine(pageTooltips.get(page));
+                button.addTooltipLines(pageTooltips.get(page));
             }
 
             y += 28;

--- a/src/main/java/org/dave/compactmachines3/gui/machine/widgets/WidgetPreviewPanel.java
+++ b/src/main/java/org/dave/compactmachines3/gui/machine/widgets/WidgetPreviewPanel.java
@@ -100,7 +100,6 @@ public class WidgetPreviewPanel extends WidgetPanel {
         renameButton.setY(5);
         renameButton.setWidth(20);
         renameButton.setHeight(20);
-        // TODO: Investigate why the tooltip wont show
         renameButton.setTooltipLines(I18n.format("gui.compactmachines3.compactsky.rename"));
 
         confirmRenameButton.addListener(MouseClickEvent.class, (event, widget) -> {
@@ -149,7 +148,6 @@ public class WidgetPreviewPanel extends WidgetPanel {
         enterButton.setWidth(20);
         enterButton.setHeight(20);
         enterButton.setVisible(shouldShowEnterButton(player));
-        // TODO: Investigate why the tooltip wont show
         enterButton.setTooltipLines(I18n.format("gui.compactmachines3.compactsky.enter"));
 
         enterButton.addListener(MouseClickEvent.class, (event, widget) -> {


### PR DESCRIPTION
This is a simple PR that fixes the tooltips in the machine preview GUI when hovering over the Name Tag and PSD which should display "Rename" and "Enter machine", respectively.

Tested and confirmed to work.