### PR TITLE
Add Basic Jade Compat for Comact Machine Block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,12 +273,20 @@ dependencies {
     compileOnly fg.deobf("mezz.jei:jei-${jei_mc_version}-forge-api:${jei_version}")
     runtimeOnly fg.deobf("mezz.jei:jei-${jei_mc_version}-forge:${jei_version}")
 
-    // The One Probe
-    implementation(fg.deobf("curse.maven:theoneprobe-245211:4629624"))
+    // Visual Data Mod
+    compileOnly fg.deobf("curse.maven:theoneprobe-245211:4629624")
+    compileOnly fg.deobf("curse.maven:jade-324717:5776962")
 
     if (!System.getenv().containsKey("CI") && include_test_mods.equals("true")) {
         // Nicephore - Screenshots and Stuff
         //runtimeOnly(fg.deobf("curse.maven:nicephore-401014:3879841"))
+
+        // Visual Data Mods
+        if (visual_info_mod.equals("theoneprobe")) {
+            implementation(fg.deobf("curse.maven:theoneprobe-245211:4629624"))
+        } else if (visual_info_mod.equals("jade")) {
+            implementation(fg.deobf("curse.maven:jade-324717:5776962"))
+        }
 
         // Testing Mods - Trash Cans, Pipez, Create, Refined Pipes, Pretty Pipes, Refined Storage
         runtimeOnly(fg.deobf("curse.maven:SuperMartijn642Core-454372:5668859"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,6 @@ jei_version=15.18.0.79
 mixin_version = 0.8.5
 mixingradle_version = 0.7-SNAPSHOT
 
-# theoneprobe or jade
-visual_info_mod = jade
 include_test_mods = true
+# theoneprobe or jade or none
+visual_info_mod = jade

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,6 @@ jei_version=15.18.0.79
 mixin_version = 0.8.5
 mixingradle_version = 0.7-SNAPSHOT
 
+# theoneprobe or jade
+visual_info_mod = jade
 include_test_mods = true

--- a/src/api/java/dev/compactmods/machines/api/core/JadeInfo.java
+++ b/src/api/java/dev/compactmods/machines/api/core/JadeInfo.java
@@ -1,0 +1,9 @@
+package dev.compactmods.machines.api.core;
+
+import net.minecraft.resources.ResourceLocation;
+
+public class JadeInfo {
+    public static final String JADE_CONFIG = "config.jade.plugin_compactmachines";
+
+    public static final ResourceLocation MACHINE = new ResourceLocation(JADE_CONFIG, "machine");
+}

--- a/src/api/java/dev/compactmods/machines/api/core/JadeInfo.java
+++ b/src/api/java/dev/compactmods/machines/api/core/JadeInfo.java
@@ -5,5 +5,7 @@ import net.minecraft.resources.ResourceLocation;
 public class JadeInfo {
     public static final String JADE_CONFIG = "config.jade.plugin_compactmachines";
 
-    public static final ResourceLocation MACHINE = new ResourceLocation(JADE_CONFIG, "machine");
+    public static final String MACHINE = JADE_CONFIG.concat(".machine");
+    public static final String MACHINE_TUNNELS = JADE_CONFIG.concat(".machine_tunnels");
+    public static final String TUNNEL_CONNECTION = JADE_CONFIG.concat(".tunnel_connection");
 }

--- a/src/datagen/java/dev/compactmods/machines/datagen/lang/EnglishLangGenerator.java
+++ b/src/datagen/java/dev/compactmods/machines/datagen/lang/EnglishLangGenerator.java
@@ -1,9 +1,6 @@
 package dev.compactmods.machines.datagen.lang;
 
-import dev.compactmods.machines.api.core.CMCommands;
-import dev.compactmods.machines.api.core.Constants;
-import dev.compactmods.machines.api.core.Messages;
-import dev.compactmods.machines.api.core.Tooltips;
+import dev.compactmods.machines.api.core.*;
 import dev.compactmods.machines.api.room.RoomSize;
 import dev.compactmods.machines.api.room.upgrade.RoomUpgrade;
 import dev.compactmods.machines.client.CreativeTabs;
@@ -108,6 +105,9 @@ public class EnglishLangGenerator extends BaseLangGenerator {
         addCommand(CMCommands.MACHINE_GIVEN, "Created a new machine item and gave it to %s.");
 
         addMessage(Messages.UNKNOWN_ROOM_CHUNK, "Unknown room at %s; please verify it exists.");
+
+        // Jade Plugin Specific Translations
+        add(JadeInfo.MACHINE.toString(), "Compact Machines");
 
         add("biome." + Constants.MOD_ID + ".machine", "Compact Machine");
 

--- a/src/datagen/java/dev/compactmods/machines/datagen/lang/EnglishLangGenerator.java
+++ b/src/datagen/java/dev/compactmods/machines/datagen/lang/EnglishLangGenerator.java
@@ -107,7 +107,10 @@ public class EnglishLangGenerator extends BaseLangGenerator {
         addMessage(Messages.UNKNOWN_ROOM_CHUNK, "Unknown room at %s; please verify it exists.");
 
         // Jade Plugin Specific Translations
-        add(JadeInfo.MACHINE.toString(), "Compact Machines");
+        add(JadeInfo.MACHINE, "Compact Machines");
+        add(JadeInfo.MACHINE_TUNNELS, "Compact Machine Tunnel Presence");
+        add(JadeInfo.TUNNEL_CONNECTION, "Tunnel Connection");
+
 
         add("biome." + Constants.MOD_ID + ".machine", "Compact Machine");
 

--- a/src/main/java/dev/compactmods/machines/compat/jade/JadePlugin.java
+++ b/src/main/java/dev/compactmods/machines/compat/jade/JadePlugin.java
@@ -1,0 +1,20 @@
+package dev.compactmods.machines.compat.jade;
+
+import dev.compactmods.machines.compat.jade.providers.CompactMachineProvider;
+import dev.compactmods.machines.machine.CompactMachineBlock;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaCommonRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+
+@WailaPlugin
+public class JadePlugin implements IWailaPlugin {
+    @Override
+    public void register(IWailaCommonRegistration registration) {
+    }
+
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(CompactMachineProvider.INSTANCE, CompactMachineBlock.class);
+    }
+}

--- a/src/main/java/dev/compactmods/machines/compat/jade/providers/CompactMachineProvider.java
+++ b/src/main/java/dev/compactmods/machines/compat/jade/providers/CompactMachineProvider.java
@@ -1,0 +1,39 @@
+package dev.compactmods.machines.compat.jade.providers;
+
+import dev.compactmods.machines.api.core.Constants;
+import dev.compactmods.machines.api.core.Tooltips;
+import dev.compactmods.machines.i18n.TranslationUtil;
+import dev.compactmods.machines.machine.CompactMachineBlockEntity;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+public class CompactMachineProvider implements IBlockComponentProvider {
+    public static final CompactMachineProvider INSTANCE = new CompactMachineProvider();
+
+    @Override
+    public void appendTooltip(
+            ITooltip tooltip,
+            BlockAccessor accessor,
+            IPluginConfig config
+    ) {
+        final CompactMachineBlockEntity machine = (CompactMachineBlockEntity) accessor.getBlockEntity();
+        machine.getConnectedRoom().ifPresentOrElse(room -> {
+            tooltip.add(TranslationUtil.tooltip(Tooltips.Machines.BOUND_TO, room));
+        }, () -> {
+            MutableComponent newMachine = TranslationUtil
+                    .message(new ResourceLocation(Constants.MOD_ID, "new_machine"))
+                    .withStyle(ChatFormatting.GREEN);
+            tooltip.add(newMachine);
+        });
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return new ResourceLocation(Constants.MOD_ID, "machine");
+    }
+}


### PR DESCRIPTION
Adds basic compatibility for Jade. Allowing switching between theoneprobe and jade in properties.