### PR TITLE
Fix a minor mistake in Compact Machine Block

### DIFF
--- a/src/main/java/dev/compactmods/machines/machine/CompactMachineBlock.java
+++ b/src/main/java/dev/compactmods/machines/machine/CompactMachineBlock.java
@@ -188,7 +188,7 @@ public class CompactMachineBlock extends Block implements EntityBlock {
     @SuppressWarnings("deprecation")
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand handIn, BlockHitResult hit) {
         if (level.isClientSide())
-            return InteractionResult.SUCCESS;
+            return InteractionResult.PASS;
 
         MinecraftServer server = level.getServer();
         ItemStack mainItem = player.getMainHandItem();
@@ -287,7 +287,7 @@ public class CompactMachineBlock extends Block implements EntityBlock {
             }
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.PASS;
     }
 
     private void createAndEnterRoom(Player player, MinecraftServer server, CompactMachineBlockEntity tile) {


### PR DESCRIPTION
Recently, I've found that there where some careless mistake in the Compact Machine Block——It's `use` method mistakely returned `ItemIntractionResult.SUCCESS` instead of `ItemIntractionResult.PASS` in the end, and which is incorrect.
For example, that means players can't eat food when they are focusd on the compact machines block, they can't place block next to the compact machines block by right click to the machine block neither.