### PR TITLE
Fix NullPointerException in JEI plugin on dedicated server

### DIFF
--- a/neoforge-main/src/main/java/dev/compactmods/machines/compat/jei/CompactMachinesJeiPlugin.java
+++ b/neoforge-main/src/main/java/dev/compactmods/machines/compat/jei/CompactMachinesJeiPlugin.java
@@ -43,10 +43,13 @@ public class CompactMachinesJeiPlugin implements IModPlugin {
                 Component.translatable("jei.compactmachines.machines"));
 
         // Add all known template JEI infos
-        RoomTemplateHelper.getTemplateHolders(ServerLifecycleHooks.getCurrentServer().registryAccess())
-                .map(Machines.Items::forNewRoom)
-                .forEach(t -> registration.addIngredientInfo(t, VanillaTypes.ITEM_STACK,
-                        Component.translatable("jei.compactmachines.machines")));
+        var server = ServerLifecycleHooks.getCurrentServer();
+        if (server != null) {
+            RoomTemplateHelper.getTemplateHolders(server.registryAccess())
+                    .map(Machines.Items::forNewRoom)
+                    .forEach(t -> registration.addIngredientInfo(t, VanillaTypes.ITEM_STACK,
+                            Component.translatable("jei.compactmachines.machines")));
+        }
 
         registration.addIngredientInfo(
                 new ItemStack(Shrinking.PERSONAL_SHRINKING_DEVICE.get()),


### PR DESCRIPTION
## Summary
- Fix `NullPointerException` in `CompactMachinesJeiPlugin.registerRecipes()` when client is connected to a dedicated server
- `ServerLifecycleHooks.getCurrentServer()` returns null on the client — added null check before accessing `registryAccess()`

## Test plan
- [ ] Connect to a dedicated server with JEI installed
- [ ] Verify no NPE in logs during recipe registration
- [ ] Verify JEI info entries still show for machines and shrinking device

🤖 Generated with [Claude Code](https://claude.com/claude-code)